### PR TITLE
Upgraded parameter handling for better searching action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
 	gem 'mocha'
 end
 
-gem 'httparty', "~> 0.6.1"
+gem 'httparty', "~> 0.7.7"
 gem 'json', "~> 1.4.6"
 gem 'rest-client', "~> 1.6.1"
 gem 'orderedhash', "~> 0.0.6"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ Install
 
 * sudo gem install brightcove-api
 
+Searching
+=========
+
+To replicate one of the brightcove search API examples:
+
+> find all videos that have "football" and "Chicago" in the name, short description, or long
+> description, and which also have the tag "free", and also have either the tag "color" or the
+> tag "technicolor"
+
+    >> brightcove = Brightcove::API.new(...)
+    >> response = brightcove.get('search_videos', {
+         :any => [ "tag:color", "tag:technicolor" ],
+         :all => ["football", "chicago", "tag:free"]
+       })
+
+
 Example
 =======
 
@@ -28,15 +44,15 @@ Example
     => {"items"=>[{"longDescription"=>nil, "name"=>"Wild Slopes '06", "lastModifiedDate"=>"1171324523307", "thumbnailURL"=>"http://brightcove.vo.llnwd.net/d2/unsecured/media/270881183/270881183_502534829_94499905676eb7cd04a558da2adcf6a34f437b88.jpg?pubId=270881183", "tags"=>["adventure", "snowboarding"], "playsTrailingWeek"=>35, "shortDescription"=>"A ski and snowboard movie that challenges the hype and dares you to see what freeskiing and snowboarding have become. Documenting the very best of this year's riding and culture.", "playsTotal"=>4458, "adKeys"=>nil, "id"=>496518766, "length"=>51251, "videoStillURL"=>"http://brightcove.vo.llnwd.net/d2/unsecured/media/270881183/270881183_502534838_f80fe64f052328cd3b2e158d7234003a23091845.jpg?pubId=270881183", "publishedDate"=>"1171324434811", "creationDate"=>"1171267200000", "linkText"=>nil, "economics"=>"FREE", "referenceId"=>"title010", "linkURL"=>nil}, {"longDescription"=>nil, "name"=>"Jellyfish", "lastModifiedDate"=>"1245181300374", "thumbnailURL"=>"http://brightcove.vo.llnwd.net/d7/unsecured/media/270881183/270881183_26530711001_jellyFish.jpg?pubId=270881183", "tags"=>["sea", "custom skins"], "playsTrailingWeek"=>46, "shortDescription"=>"Jellyfish", "playsTotal"=>4081, "adKeys"=>nil, "id"=>26512561001, "length"=>28400, "videoStillURL"=>"http://brightcove.vo.llnwd.net/d7/unsecured/media/270881183/270881183_26519430001_vs-270881183-vid26513829001-img0000.jpg?pubId=270881183", "publishedDate"=>"1245172164326", "creationDate"=>"1245172164326", "linkText"=>nil, "economics"=>"AD_SUPPORTED", "referenceId"=>nil, "linkURL"=>nil}, {"longDescription"=>"Long Description", "name"=>"Demo Title 2", "lastModifiedDate"=>"1263581295791", "thumbnailURL"=>"http://brightcove.vo.llnwd.net/d2/unsecured/media/270881183/270881183_275925069_d1f97c7f07f2a3f4de7b38eda3761f16f39d2a99.jpg?pubId=270881183", "tags"=>[], "playsTrailingWeek"=>1, "shortDescription"=>"Short Description", "playsTotal"=>3876, "adKeys"=>nil, "id"=>276024035, "length"=>418742, "videoStillURL"=>"http://brightcove.vo.llnwd.net/d2/unsecured/media/270881183/270881183_275943599_b7e2ca63c0311fa3f0b027304b41d252f12d2d66.jpg?pubId=270881183", "publishedDate"=>"1161296014264", "creationDate"=>"1161241200000", "linkText"=>"Related Link", "economics"=>"FREE", "referenceId"=>nil, "linkURL"=>"http://www.brightcove.com"}, {"longDescription"=>nil, "name"=>"Dolphins", "lastModifiedDate"=>"1263581295790", "thumbnailURL"=>"http://brightcove.vo.llnwd.net/d7/unsecured/media/270881183/270881183_26531197001_dolphins.jpg?pubId=270881183", "tags"=>["sea", "custom skins"], "playsTrailingWeek"=>30, "shortDescription"=>"Dolphins", "playsTotal"=>3870, "adKeys"=>nil, "id"=>26511963001, "length"=>12800, "videoStillURL"=>"http://brightcove.vo.llnwd.net/d7/unsecured/media/270881183/270881183_26519372001_vs-270881183-vid26510372001-img0000.jpg?pubId=270881183", "publishedDate"=>"1245171732987", "creationDate"=>"1245171732987", "linkText"=>nil, "economics"=>"AD_SUPPORTED", "referenceId"=>nil, "linkURL"=>nil}, {"longDescription"=>nil, "name"=>"Welcome to Brightcove 3", "lastModifiedDate"=>"1225134261511", "thumbnailURL"=>"http://brightcove.vo.llnwd.net/d6/unsecured/media/270881183/270881183_1858983740_brightcove3-thumb.jpg?pubId=270881183", "tags"=>[], "playsTrailingWeek"=>0, "shortDescription"=>"Tareef Kawaf, Brightcove's SVP of Engineering, welcomes you to Brightcove 3.", "playsTotal"=>3349, "adKeys"=>nil, "id"=>1858922805, "length"=>53820, "videoStillURL"=>"http://brightcove.vo.llnwd.net/d6/unsecured/media/270881183/270881183_1858994782_vid-StudioDashboards.jpg?pubId=270881183", "publishedDate"=>"1225134261508", "creationDate"=>"1224096089173", "linkText"=>nil, "economics"=>"AD_SUPPORTED", "referenceId"=>nil, "linkURL"=>nil}], "page_number"=>0, "page_size"=>5, "total_count"=>-1}
     >> response = brightcove.post('delete_video', {:video_id => '595153263001'})
   	=> {"result"=>{}, "id"=>nil, "error"=>nil}
-	
+
 If you want to perform a file upload, for example, to create a video, you can use the __post_file()__ method.
 
     >> response = brightcove.post_file('create_video', '/path/to/video.mov', :video => {:shortDescription => 'Short Description', :name => 'Video name'})
-    => {"result"=>653155417001, "error=>nil, "id"=>nil}  
-	  
+    => {"result"=>653155417001, "error=>nil, "id"=>nil}
+
 Note on Patches/Pull Requests
 =============================
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it. This is important so I don't break it in a

--- a/lib/brightcove-api.rb
+++ b/lib/brightcove-api.rb
@@ -6,74 +6,82 @@ require 'orderedhash'
 module Brightcove
   class API
     include HTTParty
-    
+    disable_rails_query_string_format
+
     VERSION = '1.0.7'.freeze
-    
+
     DEFAULT_HEADERS = {
       'User-Agent' => "brightcove-api gem #{VERSION}"
     }
-    
+
     headers(DEFAULT_HEADERS)
-        
+
     READ_API_URL = 'http://api.brightcove.com/services/library'
     WRITE_API_URL = 'http://api.brightcove.com/services/post'
-    
+
     attr_accessor :read_api_url
     attr_accessor :write_api_url
     attr_accessor :token
-        
+
     # Brightcove returns text/html as the Content-Type for a response even though the response is JSON.
     # So, let's just parse the response as JSON
     format(:json)
-    
-    # Initialize with your API token  
+
+    # Initialize with your API token
     def initialize(token, read_api_url = READ_API_URL, write_api_url = WRITE_API_URL)
       @token = token
       @read_api_url = read_api_url
       @write_api_url = write_api_url
     end
-    
+
     def debug(location = $stderr)
       self.class.debug_output(location)
     end
-        
+
     def set_http_headers(http_headers = {})
       http_headers.merge!(DEFAULT_HEADERS)
       headers(http_headers)
     end
-    
+
     def set_timeout(timeout)
       default_timeout(timeout)
     end
-    
-    # Call Brightcove using a particular API method, api_method. The options hash is where you can add any parameters appropriate for the API call.
-    def get(api_method, options = {})
-      options.merge!({:command => api_method})
-      options.merge!({:token => @token})
-      query = {}
-      query.merge!({:query => options})
 
-      self.class.get(@read_api_url, query)
+    def build_query_from_options(api_method, options = {})
+      # normalize options to a hash
+      unless options.respond_to?(:merge!)
+        options = CGI.parse(options)
+      end
+      options.merge!({:command => api_method, :token => @token})
+      { :query => options }
     end
-    
+
+    # Call Brightcove using a particular API method, api_method.
+    # The options parameter can be either a query string or a hash. In either case, it is where
+    # you can add any parameters appropriate for the API call. If a query string, it will be
+    # normalized to a hash via CGI.parse.
+    def get(api_method, options = {})
+      self.class.get(@read_api_url, build_query_from_options(api_method, options))
+    end
+
     # Post to Brightcove using a particular API method, api_method. The parameters hash is where you add all the required parameters appropriate for the API call.
-    def post(api_method, parameters = {}) 
+    def post(api_method, parameters = {})
       parameters.merge!({"token" => @token})
-      
+
       body = {}
-      body.merge!({:method => api_method})          
+      body.merge!({:method => api_method})
       body.merge!({:params => parameters})
-            
+
       self.class.post(@write_api_url, {:body => {:json => JSON.generate(body)}})
     end
-    
+
     def post_file(api_method, file, parameters = {})
       parameters.merge!({"token" => @token})
 
       body = {}
-      body.merge!({:method => api_method})          
+      body.merge!({:method => api_method})
       body.merge!({:params => parameters})
-      
+
       # Brightcove requires that the JSON-RPC call absolutely
       # be the first part of a multi-part POST like create_video.
       if RUBY_VERSION >= '1.9'
@@ -81,12 +89,12 @@ module Brightcove
       else
         payload = OrderedHash.new
       end
-      
+
       payload[:json] = body.to_json
       payload[:file] = File.new(file, 'rb')
-          
+
       response = RestClient.post(@write_api_url, payload, :content_type => :json, :accept => :json, :multipart => true)
-      
+
       JSON.parse(response)
     end
   end

--- a/test/test_brightcove-api.rb
+++ b/test/test_brightcove-api.rb
@@ -6,22 +6,22 @@ class TestBrightcoveApi < Test::Unit::TestCase
   def setup
     FakeWeb.allow_net_connect = false
   end
-  
+
   def teardown
     FakeWeb.allow_net_connect = true
   end
-  
+
   def test_api_version
     assert_equal '1.0.7', Brightcove::API::VERSION
   end
-  
+
   def test_can_set_read_api_url
     brightcove = Brightcove::API.new('apikeytoken')
-    
+
     assert_equal Brightcove::API::READ_API_URL, brightcove.read_api_url
-    
+
     brightcove.read_api_url = 'http://some.api.com'
-    
+
     assert_equal 'http://some.api.com', brightcove.read_api_url
   end
 
@@ -31,65 +31,117 @@ class TestBrightcoveApi < Test::Unit::TestCase
     assert_equal Brightcove::API::WRITE_API_URL, brightcove.write_api_url
 
     brightcove.write_api_url = 'http://some.api.com'
-    
+
     assert_equal 'http://some.api.com', brightcove.write_api_url
   end
-  
+
   def test_can_set_token
     brightcove = Brightcove::API.new('apikeytoken')
-    
+
     assert_equal 'apikeytoken', brightcove.token
   end
-  
+
   def test_can_set_http_headers
     brightcove = Brightcove::API.new('apikeytoken')
     brightcove.expects(:headers).at_least_once
-    
+
     brightcove.set_http_headers({'Accept' => 'application/json'})
   end
-  
+
   def test_can_set_timeout
     brightcove = Brightcove::API.new('apikeytoken')
     brightcove.expects(:default_timeout).at_least_once
-    
+
     brightcove.set_timeout(5)
   end
-  
+
   def test_find_all_videos
-    FakeWeb.register_uri(:get, 
-                         'http://api.brightcove.com/services/library?page_size=5&token=0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.&command=find_all_videos', 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'find_all_videos_response.json'), 
-                         :content_type => "application/json")
-                         
-    brightcove = Brightcove::API.new('0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.')
-    brightcove_response = brightcove.get('find_all_videos', {:page_size => 5})
-    
-    assert_equal 5, brightcove_response['items'].size
-    assert_equal 0, brightcove_response['page_number']
-  end
-  
-  def test_delete_video
-    FakeWeb.register_uri(:post, 
-                         'http://api.brightcove.com/services/post', 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'delete_video_response.json'), 
-                         :content_type => "application/json")
-                         
-    brightcove = Brightcove::API.new('0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.')
-    brightcove_response = brightcove.post('delete_video', {:video_id => '595153261337'})
-    
-    assert brightcove_response.has_key?('result')
-    assert_equal brightcove_response['error'], 'nil'
-  end
-  
-  def test_create_video_using_post_file
-    FakeWeb.register_uri(:post, 
-                         'http://api.brightcove.com/services/post', 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'create_video_response.json'), 
+    FakeWeb.register_uri(:get,
+                         'http://api.brightcove.com/services/library?page_size=5&token=0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.&command=find_all_videos',
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'find_all_videos_response.json'),
                          :content_type => "application/json")
 
     brightcove = Brightcove::API.new('0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.')
-    brightcove_response = brightcove.post_file('create_video', 
-      File.join(File.dirname(__FILE__), 'fakeweb', 'movie.mov'), 
+    brightcove_response = brightcove.get('find_all_videos', {:page_size => 5})
+
+    assert_equal 5, brightcove_response['items'].size
+    assert_equal 0, brightcove_response['page_number']
+  end
+
+  def test_search_with_array_params
+    brightcove = Brightcove::API.new('0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.')
+    brightcove.class.expects(:get).with(anything, has_entry(:query => {
+      :any => ['tag:foo', 'tag:bar'],
+      :command => 'search_videos',
+      :token => '0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.'
+    }))
+    brightcove_response = brightcove.get('search_videos', { :any => [ "tag:foo", "tag:bar" ] })
+  end
+
+  def test_search_with_string_params
+    brightcove = Brightcove::API.new('0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.')
+    brightcove.class.expects(:get).with(anything, has_entry(:query => {
+      'any' => ['tag:bar', 'tag:foo'],
+      :command => 'search_videos',
+      :token => '0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.'
+    }))
+    brightcove_response = brightcove.get('search_videos', 'any=tag:bar&any=tag:foo' )
+  end
+
+  def test_more_complicated_query
+    brightcove = Brightcove::API.new('0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.')
+    brightcove.class.expects(:get).with(anything, has_entry(:query => {
+      :any => ['tag:foo', 'tag:bar'],
+      :all => "search_text:foo",
+      :command => 'search_videos',
+      :token => '0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.'
+    }))
+    brightcove_response = brightcove.get('search_videos', { :any => [ "tag:foo", "tag:bar" ], :all => "search_text:foo" })
+  end
+
+  def test_brightcove_example_query
+    FakeWeb.register_uri(:get,
+                         'http://api.brightcove.com/services/library?all=chicago&all=football&all=tag%3Afree&any=tag%3Acolor&any=tag%3Atechnicolor&command=search_videos&token=1234.',
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'find_all_videos_response.json'),
+                         :content_type => "application/json")
+
+    brightcove = Brightcove::API.new('1234.')
+    # brightcove.class.expects(:get).with(anything, has_entry(:query => {
+    #   :any => ['tag:color', 'tag:technicolor'],
+    #   :all => ['football', 'chicago', 'tag:free'],
+    #   :command => 'search_videos',
+    #   :token => '1234.'
+    # }))
+    brightcove_response = brightcove.get('search_videos', {
+      :any => [ "tag:color", "tag:technicolor" ],
+      :all => ["football", "chicago", "tag:free"]
+    })
+
+    assert_equal 5, brightcove_response['items'].size
+  end
+
+  def test_delete_video
+    FakeWeb.register_uri(:post,
+                         'http://api.brightcove.com/services/post',
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'delete_video_response.json'),
+                         :content_type => "application/json")
+
+    brightcove = Brightcove::API.new('0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.')
+    brightcove_response = brightcove.post('delete_video', {:video_id => '595153261337'})
+
+    assert brightcove_response.has_key?('result')
+    assert_equal brightcove_response['error'], 'nil'
+  end
+
+  def test_create_video_using_post_file
+    FakeWeb.register_uri(:post,
+                         'http://api.brightcove.com/services/post',
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'create_video_response.json'),
+                         :content_type => "application/json")
+
+    brightcove = Brightcove::API.new('0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.')
+    brightcove_response = brightcove.post_file('create_video',
+      File.join(File.dirname(__FILE__), 'fakeweb', 'movie.mov'),
       :video => {:shortDescription => "Short Description", :name => "Video"})
 
     assert brightcove_response.has_key?('result')


### PR DESCRIPTION
Specifying a new version of HTTParty so that we can disable rails-style handling of multiple-values-for-one-key uri strings. Now allowing the 'options' parameter to #get to be a query string. Updated README.md. My text editor hates extraneous whitespace.

Let me know if you have any test failures due to array-ordering issues (e.g. the expectation is for params to be in one order, but they come out in another on your machine); obviously, let me know about test failures in general, but I'm not sure how to convince test::unit/mocha to not care about the order of things so that might be a problem.

Also, I _hate_ extraneous whitespace at the end of lines, so I have my editor strip it out. Sorry about all the whitespace-only changes :).
