### PR TITLE
allow UploadIO to be passed in to post_io_streaming

### DIFF
--- a/lib/brightcove-api.rb
+++ b/lib/brightcove-api.rb
@@ -162,7 +162,7 @@ module Brightcove
       response = nil
       
       payload[:json] = body.to_json
-      payload[:file] = UploadIO.new(file, content_type)
+      payload[:file] = file.is_a?(UploadIO) ? file : UploadIO.new(file, content_type)
       
       request = Net::HTTP::Post::Multipart.new(url.path, payload)
       


### PR DESCRIPTION
In some cases you already have an **UploadIO** object and you might want to pass it to **post_io_stream** directly.
