### PR TITLE
Change to https

### DIFF
--- a/lib/brightcove-api.rb
+++ b/lib/brightcove-api.rb
@@ -18,8 +18,8 @@ module Brightcove
 
     headers(DEFAULT_HEADERS)
 
-    READ_API_URL = 'http://api.brightcove.com/services/library'
-    WRITE_API_URL = 'http://api.brightcove.com/services/post'
+    READ_API_URL = 'https://api.brightcove.com/services/library'
+    WRITE_API_URL = 'https://api.brightcove.com/services/post'
 
     attr_accessor :read_api_url
     attr_accessor :write_api_url


### PR DESCRIPTION
I got a request from David Lea (Bcov SE) to have Zencoder's VideoCloud syndication go over https instead of http. We're using the gem - any issues with doing this?

Also - I noticed that 1.0.15 is on Github but 1.0.14 is the version published to Rubygems.
