### PR TITLE
Use ssl for streaming api

### DIFF
--- a/lib/brightcove-api.rb
+++ b/lib/brightcove-api.rb
@@ -174,7 +174,7 @@ module Brightcove
 
       request = Net::HTTP::Post::Multipart.new(url.path, payload)
 
-      response = Net::HTTP.start(url.host, url.port) do |http|
+      response = Net::HTTP.start(url.host, url.port, :use_ssl => true) do |http|
         http.read_timeout = @timeout if @timeout
         http.open_timeout = @open_timeout if @open_timeout
         http.request(request)


### PR DESCRIPTION
Trying to use the streaming API without this results in an unhelpful "Broken Pipe" error when using the streaming APIs. See https://gist.github.com/paul/0d7dde73ef00490a8b82